### PR TITLE
Add Datadog tracing info when available [TER-11370]

### DIFF
--- a/grape_log_formatter.gemspec
+++ b/grape_log_formatter.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "lograge"
   spec.add_dependency "grape_logging", "~> 1.8.0"
 
-  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "bundler", ">= 1.16"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec"
 

--- a/lib/grape_log_formatter/formatters/custom_format.rb
+++ b/lib/grape_log_formatter/formatters/custom_format.rb
@@ -7,7 +7,7 @@ module GrapeLogFormatter
         lograge_format = super
 
         if defined?(Datadog::Tracing.log_correlation)
-          dd_format = "[#{Datadog::Tracing.log_correlation}] "
+          dd_format = " [#{Datadog::Tracing.log_correlation}]"
         else
           dd_format = ""
         end

--- a/lib/grape_log_formatter/formatters/custom_format.rb
+++ b/lib/grape_log_formatter/formatters/custom_format.rb
@@ -6,7 +6,13 @@ module GrapeLogFormatter
       def call(severity, datetime, _, data)
         lograge_format = super
 
-        "[#{datetime.strftime('%Y-%m-%d %H:%M:%S')}] #{severity} -- #{lograge_format}\n"
+        if defined?(Datadog::Tracing.log_correlation)
+          dd_format = "[#{Datadog::Tracing.log_correlation}] "
+        else
+          dd_format = ""
+        end
+
+        "[#{datetime.strftime('%Y-%m-%d %H:%M:%S')}] #{severity} -- #{lograge_format} #{dd_format}\n"
       end
     end
   end

--- a/lib/grape_log_formatter/version.rb
+++ b/lib/grape_log_formatter/version.rb
@@ -1,3 +1,3 @@
 module GrapeLogFormatter
-  VERSION = "0.1.1"
+  VERSION = "0.2.1"
 end

--- a/spec/grape_log_formatter/formatters/custom_format_spec.rb
+++ b/spec/grape_log_formatter/formatters/custom_format_spec.rb
@@ -30,5 +30,21 @@ describe GrapeLogFormatter::Formatters::CustomFormat do
         expect(subject).to include("#{key}=#{value}")
       end
     end
+
+    describe "datadog" do
+      module Datadog
+        class Tracing
+        end
+      end
+
+      it "does not include dd.trace_id" do
+        expect(subject).not_to include("dd.trace_id")
+      end
+
+      it "includes dd.trace_id when Datadog tracing is configured" do
+        allow(Datadog::Tracing).to receive(:log_correlation).and_return("[dd.trace_id=123]")
+        expect(subject).to include("dd.trace_id")
+      end
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require 'bundler/setup'
 Bundler.setup
 
+require 'grape'
 require 'grape_log_formatter'
 require 'rspec'
 


### PR DESCRIPTION
Our grape logs don't include any ddtrace info. This means most of our
logs are not correlated with APM traces. To fix that, if/when Datadog is
available include the log_correlation info in the log message.