### PR TITLE
Put the log and ddtrace info on a single line [TER-11370]

### DIFF
--- a/lib/grape_log_formatter/formatters/custom_format.rb
+++ b/lib/grape_log_formatter/formatters/custom_format.rb
@@ -7,12 +7,12 @@ module GrapeLogFormatter
         lograge_format = super
 
         if defined?(Datadog::Tracing.log_correlation)
-          dd_format = " [#{Datadog::Tracing.log_correlation}]"
+          dd_format = " #{Datadog::Tracing.log_correlation}"
         else
           dd_format = ""
         end
 
-        "[#{datetime.strftime('%Y-%m-%d %H:%M:%S')}] #{severity} -- #{lograge_format} #{dd_format}\n"
+        "[#{datetime.strftime('%Y-%m-%d %H:%M:%S')}] #{severity} --#{dd_format} #{lograge_format}"
       end
     end
   end

--- a/lib/grape_log_formatter/version.rb
+++ b/lib/grape_log_formatter/version.rb
@@ -1,3 +1,3 @@
 module GrapeLogFormatter
-  VERSION = "0.2.1"
+  VERSION = "0.2.2"
 end


### PR DESCRIPTION
With the previous change, it wasn't obvious that the `lograge_format`
variable included a newline. So when I added additional log data after,
it showed up on a new line. This was not what we want. The options were
to just place the dd info first rather than last, or build it into the
data, rather than using the supplied variable from datadog. I just went
with putting it first.
